### PR TITLE
Fix(tests): Recognize `.common.` varfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ terraform.rc
 
 /vars/**
 !/vars/**.example
+!/vars/**.ci.**
+!/vars/**.common.**
 
 /logs
 /plans

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -21,12 +21,13 @@ func retrieveVarFiles(t *testing.T) []string {
 	for _, file := range files {
 		filename := file.Name()
 		isDisabled := strings.Contains(filename, ".disabled.")
+		isCommon := strings.Contains(filename, ".common.")
 		isTfVars := strings.HasSuffix(filename, ".tfvars")
 		isTfVarsJson := strings.HasSuffix(filename, ".tfvars.json")
 		isExample := strings.HasSuffix(filename, ".example")
 		environment := environment.GetFirstNonEmptyEnvVarOrFatal(t, []string {"ENVIRONMENT"})
 		isOfCurrentEnvironment := strings.Contains(filename, fmt.Sprintf(".%s.", environment))
-		if !isDisabled && (isTfVars || isTfVarsJson) && !isExample && isOfCurrentEnvironment {
+		if !isDisabled && (isTfVars || isTfVarsJson) && !isExample && (isOfCurrentEnvironment || isCommon) {
 			varFiles = append(varFiles, fmt.Sprintf("%s/%s", varsFolder, filename))
 		}
 	}


### PR DESCRIPTION
- Close #7 by adding `isCommon` bool value in `utils.go:24`. This
  var tracks whether the filename contains `.common.` substring.
  Files with this substring are meant to contain values for all
  environments.
- Add `*.common.*` to `.gitignore` ignore list, so this file is
  allowed in git.
