### PR TITLE
Fix: Remove obsolete reference from script

### DIFF
--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-source scripts/git-checks.sh || exit 1
-source scripts/terraform-checks.sh || exit 2
+source scripts/terraform-checks.sh || exit 1
 check_env_for_terraform_values
 check_repo_config
 check_tfvars_in_repo_config


### PR DESCRIPTION
- Close #12 by removing reference to `git-checks.sh` in
  `terraform.sh:3`. This line was left from the time repo updater was
  coupled with the rest of the scripts as a part of tf-repo-template.
  When elam was spun off as its own repo, the reference remained but
  became a bug.
