### PR TITLE
Chore: Alter gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ terraform.rc
 
 *.issue.md
 *.pr.md
+/.certs


### PR DESCRIPTION
- Add `.certs` to gitignore. This path houses certs and it shouldn't be
  available in VC.
