### PR TITLE
Fix: Alter `post-create-command.sh` tests handling

### DIFF
--- a/scripts/post-create-command.sh
+++ b/scripts/post-create-command.sh
@@ -2,6 +2,6 @@
 
 terraform init
 
-cd tests && go mod tidy && cd ..
+cd tests && go mod tidy; cd ..
 
 .elam/update-status.sh


### PR DESCRIPTION
- Alter `post-create-command.sh` tests command to `cd ..` regardless
  of the previous command. This is done because in the previous state of
  the code, if the test update fails, directory change doesn't run,
  which inevitably causes issues downstream.
